### PR TITLE
Remove: support for not having getifaddr

### DIFF
--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -3849,6 +3849,7 @@ STR_VEHICLE_LIST_MANAGE_LIST                                    :{BLACK}Lijst be
 STR_VEHICLE_LIST_MANAGE_LIST_TOOLTIP                            :{BLACK}Stuur instructies naar alle voertuigen in de lijst
 STR_VEHICLE_LIST_REPLACE_VEHICLES                               :Vervang voertuigen
 STR_VEHICLE_LIST_SEND_FOR_SERVICING                             :Stuur voor onderhoud
+STR_VEHICLE_LIST_CREATE_GROUP                                   :Groep maken
 STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR                     :{TINY_FONT}{BLACK}Winst dit jaar: {CURRENCY_LONG} (vorig jaar: {CURRENCY_LONG})
 STR_VEHICLE_LIST_CARGO                                          :[{CARGO_LIST}]
 STR_VEHICLE_LIST_NAME_AND_CARGO                                 :{STRING} {STRING}
@@ -4571,6 +4572,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Verwacht
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Volgens dienstregeling
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Wissel tussen verwacht en volgens dienstregeling
 
+STR_TIMETABLE_ARRIVAL                                           :A: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :D: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)
@@ -5625,6 +5628,8 @@ STR_JUST_DATE_SHORT                                             :{DATE_SHORT}
 STR_JUST_DATE_LONG                                              :{DATE_LONG}
 STR_JUST_DATE_ISO                                               :{DATE_ISO}
 STR_JUST_STRING                                                 :{STRING}
+STR_JUST_STRING1                                                :{STRING}
+STR_JUST_STRING2                                                :{STRING}
 STR_JUST_STRING_STRING                                          :{STRING}{STRING}
 STR_JUST_RAW_STRING                                             :{STRING}
 STR_JUST_BIG_RAW_STRING                                         :{BIG_FONT}{STRING}

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -4572,6 +4572,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Expected
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Scheduled
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Switch between expected and scheduled
 
+STR_TIMETABLE_ARRIVAL                                           :A: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :D: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -585,7 +585,7 @@ STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Forigu ĉiujn m
 STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Landkvadrataj informoj
 STR_ABOUT_MENU_SEPARATOR                                        :
 STR_ABOUT_MENU_TOGGLE_CONSOLE                                   :Baskuligi Konzolon
-STR_ABOUT_MENU_AI_DEBUG                                         :AI/Ludo skripto sencimigo
+STR_ABOUT_MENU_AI_DEBUG                                         :AI/Ludoskripta sencimigo
 STR_ABOUT_MENU_SCREENSHOT                                       :Ekranfoto
 STR_ABOUT_MENU_SHOW_FRAMERATE                                   :Montru bildrapidon
 STR_ABOUT_MENU_ABOUT_OPENTTD                                    :Pri 'OpenTTD'
@@ -1015,6 +1015,7 @@ STR_GAME_OPTIONS_TAB_SOUND                                      :Sono
 STR_GAME_OPTIONS_TAB_SOUND_TT                                   :{BLACK}Elektu agordojn pri sono kaj muziko
 
 STR_GAME_OPTIONS_VOLUME                                         :Laŭteco
+STR_GAME_OPTIONS_SFX_VOLUME                                     :Sonefektoj
 STR_GAME_OPTIONS_MUSIC_VOLUME                                   :Muziko
 
 STR_GAME_OPTIONS_VOLUME_0                                       :0%
@@ -1097,6 +1098,7 @@ STR_GAME_OPTIONS_VIDEO_ACCELERATION                             :{BLACK}Aparatar
 STR_GAME_OPTIONS_VIDEO_ACCELERATION_TOOLTIP                     :{BLACK}Elektu tiun ĉi agordon por ke OpenTTD klopodu uzi aparataran akceladon. Se vi ŝanĝas tiun ĉi agordon, la nova agordo validos nur ekde restartigo de la ludo
 STR_GAME_OPTIONS_VIDEO_ACCELERATION_RESTART                     :{WHITE}Tiu ĉi agordo ekefikos nur post restartigo de la ludo
 
+STR_GAME_OPTIONS_VIDEO_VSYNC                                    :{BLACK}Vertikala sinkronigo
 
 STR_GAME_OPTIONS_VIDEO_DRIVER_INFO                              :{BLACK}Nuna pelilo: {STRING}
 
@@ -1119,8 +1121,10 @@ STR_GAME_OPTIONS_PARTICIPATE_SURVEY_PREVIEW_TOOLTIP             :{BLACK}Montru l
 
 STR_GAME_OPTIONS_GRAPHICS                                       :{BLACK}Grafiko
 
+STR_GAME_OPTIONS_REFRESH_RATE                                   :{BLACK}Montru aktualigoftecon
 STR_GAME_OPTIONS_REFRESH_RATE_TOOLTIP                           :{BLACK}Elektu ekranan aktualigoftecon
 STR_GAME_OPTIONS_REFRESH_RATE_ITEM                              :{NUM}Hz
+STR_GAME_OPTIONS_REFRESH_RATE_WARNING                           :{WHITE}Aktualigoftecoj pli altaj ol 60Hz povas kaŭzi malrapidiĝon.
 
 STR_GAME_OPTIONS_BASE_GRF                                       :{BLACK}Baza grafikaro
 STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Selektu la uzendan bazgrafikaron
@@ -1311,6 +1315,7 @@ STR_CONFIG_SETTING_RUNNING_COSTS                                :Irkostoj: {STRI
 STR_CONFIG_SETTING_RUNNING_COSTS_HELPTEXT                       :Ŝanĝu nivelon de bontenkostoj kaj irkostoj de veturiloj kaj infrastrukturo
 
 STR_CONFIG_SETTING_CONSTRUCTION_SPEED                           :Konstrurapido: {STRING}
+STR_CONFIG_SETTING_CONSTRUCTION_SPEED_HELPTEXT                  :Limigu la kvanton de konstruaj agoj por AIoj
 
 STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS                           :Veturilpaneoj: {STRING}
 STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS_HELPTEXT                  :Regu kiom ofte povas panei maladekvate prizorgataj veturiloj
@@ -1352,6 +1357,7 @@ STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT                           :Permesu terenŝ
 STR_CONFIG_SETTING_CATCHMENT                                    :Permesu pli realismajn grandecojn de servataj areoj: {STRING}
 STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Diversaj tipoj de stacioj kaj flughavenoj havas diversgrandajn servatajn areojn
 
+STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Kompaniaj stacioj povas servi fabrikojn kun alkroĉitaj neŭtralaj stacioj: {STRING}
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :Kiam tiu ĉi agordo estas aktiva, fabrikoj kun alkroĉitaj stacioj (ekzemple oleplatformoj) povas ankaŭ esti servataj de apudaj stacioj konstruitaj de kompanioj. Kiam tiu ĉi agordo estas malaktiva, tiaj ĉi fabrikoj serveblas nur per siaj alkroĉitaj stacioj. Apudaj stacioj konstruitaj de kompanioj ne povos servi ilin, kaj la alkroĉita stacio ankaŭ ne servos ion alian ol la fabrikon mem
 
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Permesu forigon de pli da urbaj stratoj, pontoj ktp: {STRING}
@@ -1767,6 +1773,7 @@ STR_CONFIG_SETTING_AI_BUILDS_SHIPS                              :Malebligu ŝipo
 STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT                     :Se tiu ĉi agordo estas aktiva, komputila ludanto ne povas konstrui ŝipojn
 
 STR_CONFIG_SETTING_AI_PROFILE                                   :Defaŭlta agorda profilo: {STRING}
+STR_CONFIG_SETTING_AI_PROFILE_HELPTEXT                          :Elektu kiun agordaron uzi por hazardaj AIoj aŭ por komencaj valoroj dum aldonado de nova AI aŭ ludoskripto
 ###length 3
 STR_CONFIG_SETTING_AI_PROFILE_EASY                              :Facila
 STR_CONFIG_SETTING_AI_PROFILE_MEDIUM                            :Mezfacila
@@ -2391,6 +2398,7 @@ STR_NETWORK_CLIENT_LIST_PLAYER_NAME                             :{BLACK}Nomo
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME_TOOLTIP                     :{BLACK}Via ludantnomo
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME_EDIT_TOOLTIP                :{BLACK}Ŝanĝu vian ludantonomon
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME_QUERY_CAPTION               :Via ludantnomo
+STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_TOOLTIP                    :{BLACK}Administraj agoj fareblaj por tiu ĉi kliento
 STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_TOOLTIP                   :{BLACK}Administraj agoj fareblaj por tiu ĉi kompanio
 STR_NETWORK_CLIENT_LIST_JOIN_TOOLTIP                            :{BLACK}Aliĝu al tiu ĉi kompanio
 STR_NETWORK_CLIENT_LIST_CHAT_CLIENT_TOOLTIP                     :{BLACK}Sendu mesaĝon al tiu ĉi ludanto
@@ -3077,6 +3085,12 @@ STR_ABOUT_COPYRIGHT_OPENTTD                                     :{BLACK}OpenTTD 
 # Framerate display window
 STR_FRAMERATE_CAPTION                                           :{WHITE}Bildrapido
 STR_FRAMERATE_CAPTION_SMALL                                     :{STRING}{WHITE} ({DECIMAL}x)
+STR_FRAMERATE_RATE_GAMELOOP                                     :{BLACK}Rapido de simulado: {STRING}
+STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP                             :{BLACK}Nombro de tempopulsoj simulataj ĉiusekunde.
+STR_FRAMERATE_RATE_BLITTER                                      :{BLACK}Grafika bildrapido: {STRING}
+STR_FRAMERATE_RATE_BLITTER_TOOLTIP                              :{BLACK}Nombro de bildokadroj montrataj ĉiusekunde.
+STR_FRAMERATE_SPEED_FACTOR                                      :{BLACK}Nuna ludrapideca faktoro: {DECIMAL}x
+STR_FRAMERATE_SPEED_FACTOR_TOOLTIP                              :{BLACK}Kiom rapide la ludo nun iras, kompare al la atendata rapideco je normala simuladrapido.
 STR_FRAMERATE_CURRENT                                           :{WHITE}Nuna
 STR_FRAMERATE_AVERAGE                                           :{WHITE}Averaĝa
 STR_FRAMERATE_MEMORYUSE                                         :{WHITE}Memory
@@ -3092,21 +3106,36 @@ STR_FRAMERATE_GRAPH_MILLISECONDS                                :{TINY_FONT}{COM
 STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COMMA} s
 
 ###length 15
+STR_FRAMERATE_GAMELOOP                                          :{BLACK}Luda iteracio ensume:
 STR_FRAMERATE_GL_ECONOMY                                        :{BLACK} Traktado de ŝarĝoj:
+STR_FRAMERATE_GL_TRAINS                                         :{BLACK}  Trajnaj tempopulsoj:
+STR_FRAMERATE_GL_ROADVEHS                                       :{BLACK}  Stratveturilaj tempopulsoj:
+STR_FRAMERATE_GL_SHIPS                                          :{BLACK}  Ŝipaj tempopulsoj:
+STR_FRAMERATE_GL_AIRCRAFT                                       :{BLACK}  Aviadilaj tempopulsoj:
+STR_FRAMERATE_GL_LANDSCAPE                                      :{BLACK}  Mondaj tempopulsoj:
 STR_FRAMERATE_GL_LINKGRAPH                                      :{BLACK} Ligografea prokrasto:
 STR_FRAMERATE_DRAWING                                           :{BLACK}Grafika bildigo:
+STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{BLACK}  Mondaj vidujoj:
 STR_FRAMERATE_VIDEO                                             :{BLACK}Videa eligo:
 STR_FRAMERATE_SOUND                                             :{BLACK}Sonmiksado:
+STR_FRAMERATE_ALLSCRIPTS                                        :{BLACK}  Ludoskriptoj/AI ensume:
 STR_FRAMERATE_GAMESCRIPT                                        :{BLACK} Ludoskripto:
 STR_FRAMERATE_AI                                                :{BLACK}   AI {NUM} {STRING}
 
 ###length 15
 STR_FRAMETIME_CAPTION_GAMELOOP                                  :Luda iteracio
 STR_FRAMETIME_CAPTION_GL_ECONOMY                                :Traktado de ŝarĝoj
+STR_FRAMETIME_CAPTION_GL_TRAINS                                 :Trajnaj tempopulsoj
+STR_FRAMETIME_CAPTION_GL_ROADVEHS                               :Stratveturilaj tempopulsoj
+STR_FRAMETIME_CAPTION_GL_SHIPS                                  :Ŝipaj tempopulsoj
+STR_FRAMETIME_CAPTION_GL_AIRCRAFT                               :Aviadilaj tempopulsoj
+STR_FRAMETIME_CAPTION_GL_LANDSCAPE                              :Mondaj tempopulsoj
 STR_FRAMETIME_CAPTION_GL_LINKGRAPH                              :Ligografea prokrasto
 STR_FRAMETIME_CAPTION_DRAWING                                   :Grafika bildigo
+STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :Bildigo de mondaj vidujoj
 STR_FRAMETIME_CAPTION_VIDEO                                     :Videa eligo
 STR_FRAMETIME_CAPTION_SOUND                                     :Sonmiksado
+STR_FRAMETIME_CAPTION_ALLSCRIPTS                                :Ludoskriptoj/AIoj ensume
 STR_FRAMETIME_CAPTION_GAMESCRIPT                                :Ludoskripto
 STR_FRAMETIME_CAPTION_AI                                        :AI {NUM} {STRING}
 
@@ -3333,6 +3362,8 @@ STR_SPRITE_ALIGNER_MOVE_TOOLTIP                                 :{BLACK}Movadi l
 
 STR_SPRITE_ALIGNER_CROSSHAIR                                    :{BLACK}Celkruco
 
+STR_SPRITE_ALIGNER_RESET_TOOLTIP                                :{BLACK}Restarigu la nunajn relativajn deŝovojn
+STR_SPRITE_ALIGNER_OFFSETS_REL                                  :{BLACK}X-deŝovo: {NUM}, Y-deŝovo: {NUM} (Relativa)
 STR_SPRITE_ALIGNER_PICKER_BUTTON                                :{BLACK}Elektu bildeto
 STR_SPRITE_ALIGNER_PICKER_TOOLTIP                               :{BLACK}Elektu bildeton ie el la ekrano
 
@@ -3491,6 +3522,7 @@ STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{PUSH_COLOUR}{Y
 STR_GOALS_CAPTION                                               :{WHITE}Celoj de {COMPANY}
 STR_GOALS_COMPANY_BUTTON                                        :{BLACK}Kompanio
 STR_GOALS_COMPANY_BUTTON.n                                      :{BLACK}Kompanion
+STR_GOALS_COMPANY_BUTTON_HELPTEXT                               :{BLACK}Montru celojn de la kompanio
 STR_GOALS_TEXT                                                  :{ORANGE}{STRING}
 STR_GOALS_NONE                                                  :{ORANGE}- Nenia -
 STR_GOALS_PROGRESS                                              :{ORANGE}{STRING}
@@ -3564,7 +3596,10 @@ STR_STATION_VIEW_SUPPLY_RATINGS_TITLE                           :{BLACK}Ĉiumona
 STR_STATION_VIEW_CARGO_SUPPLY_RATING                            :{WHITE}{STRING}: {YELLOW}{COMMA} / {STRING} ({COMMA}%)
 
 STR_STATION_VIEW_GROUP                                          :{BLACK}Grupigu laŭ
+STR_STATION_VIEW_WAITING_STATION                                :Stacio: Atendanta
+STR_STATION_VIEW_WAITING_AMOUNT                                 :Kvanto: Atendanta
 STR_STATION_VIEW_PLANNED_STATION                                :Stacio: Planata
+STR_STATION_VIEW_PLANNED_AMOUNT                                 :Kvanto: Planita
 STR_STATION_VIEW_FROM                                           :{YELLOW}{CARGO_SHORT} de {STATION}
 STR_STATION_VIEW_VIA                                            :{YELLOW}{CARGO_SHORT} tra {STATION}
 STR_STATION_VIEW_TO                                             :{YELLOW}{CARGO_SHORT} al {STATION}
@@ -4334,6 +4369,7 @@ STR_ORDER_CONDITIONAL_REMAINING_LIFETIME                        :Resta vivo (jar
 STR_ORDER_CONDITIONAL_MAX_RELIABILITY                           :Maksimuma fidindeco
 ###next-name-looks-similar
 
+STR_ORDER_CONDITIONAL_COMPARATOR_TOOLTIP                        :{BLACK}Kiel kompari la veturilajn datumoj al la donita valoro
 STR_ORDER_CONDITIONAL_COMPARATOR_EQUALS                         :egalas al
 STR_ORDER_CONDITIONAL_COMPARATOR_NOT_EQUALS                     :ne egalas al
 STR_ORDER_CONDITIONAL_COMPARATOR_LESS_THAN                      :estas malpli ol
@@ -4472,6 +4508,7 @@ STR_TIMETABLE_CHANGE_TIME                                       :{BLACK}Ŝanĝu 
 STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Ŝanĝu kiom da tempo devus postuli la markita ordono. Stir+Klak ŝanĝas la tempon por ĉiuj ordonoj
 
 STR_TIMETABLE_CLEAR_TIME                                        :{BLACK}Vakigi tempon
+STR_TIMETABLE_CLEAR_TIME_TOOLTIP                                :{BLACK}Forviŝu la tempokvanton por la markita ordono. Ctrl+Klak forviŝas tempokvantojn por ĉiuj ordonoj
 
 STR_TIMETABLE_CHANGE_SPEED                                      :{BLACK}Ŝanĝu rapideclimon
 STR_TIMETABLE_CHANGE_SPEED_TOOLTIP                              :{BLACK}Ŝanĝu la maksimuman veturrapidecon de la markita ordono. Stir+Klak ŝanĝas la rapidecon por ĉiuj ordonoj
@@ -4483,11 +4520,14 @@ STR_TIMETABLE_RESET_LATENESS                                    :{BLACK}Reigu ma
 STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reigu malfruan kalkulumon, tiel la veturilon estos akuratan
 
 STR_TIMETABLE_AUTOFILL                                          :{BLACK}Aŭtomata plenigo
+STR_TIMETABLE_AUTOFILL_TOOLTIP                                  :{BLACK}Aŭtomate plenigu la horaron per la valoroj de la sekva iro. Ctrl+Klak por klopodi konservi atendodaŭrojn
 
 STR_TIMETABLE_EXPECTED                                          :{BLACK}Atendite
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Planite
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Ŝalti inter atendite kaj planite
 
+STR_TIMETABLE_ARRIVAL                                           :A: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :E: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)
@@ -4500,7 +4540,7 @@ STR_DATE_YEAR_TOOLTIP                                           :{BLACK}Elekti j
 
 
 # AI debug window
-STR_AI_DEBUG                                                    :{WHITE}AI/Ludo Skripto Sencimigo
+STR_AI_DEBUG                                                    :{WHITE}AI/Ludoskripta Sencimigo
 STR_AI_DEBUG_NAME_AND_VERSION                                   :{BLACK}{STRING} (v{NUM})
 STR_AI_DEBUG_NAME_TOOLTIP                                       :{BLACK}Nomo de la skripto
 STR_AI_DEBUG_SETTINGS                                           :{BLACK}Agordoj
@@ -4518,11 +4558,14 @@ STR_AI_DEBUG_SELECT_AI_TOOLTIP                                  :{BLACK}Vidu for
 STR_AI_GAME_SCRIPT                                              :{BLACK}Ludoskripto
 STR_AI_GAME_SCRIPT_TOOLTIP                                      :{BLACK}Kontrolu la ludoskriptan protokolon
 
+STR_ERROR_AI_NO_AI_FOUND                                        :Neniu taŭga AI estas ŝarĝebla.{}Tiu ĉi AI estas lokokupa AI kiu nenion faros.{}Vi povas elŝuti pliajn AIojn per la 'Enreta Enhavo'-sistemo
+STR_ERROR_AI_PLEASE_REPORT_CRASH                                :{WHITE}Unu el la rulantaj skriptoj paneis. Bonvolu raporti tion ĉi al la aŭtoro de la skripto kun ekrankapto de la fenestro 'AI/Ludoskripta Sencimigo'
 
 # AI configuration window
 STR_AI_CONFIG_CAPTION_AI                                        :{WHITE}AI-agordoj
 STR_AI_CONFIG_CAPTION_GAMESCRIPT                                :{WHITE}Ludoskriptaj agordoj
 STR_AI_CONFIG_GAMELIST_TOOLTIP                                  :{BLACK}Ludoskripto ŝarĝota en la sekva ludo
+STR_AI_CONFIG_AILIST_TOOLTIP                                    :{BLACK}La AIoj ŝarĝotaj en la sekva ludo
 STR_AI_CONFIG_HUMAN_PLAYER                                      :Homa ludanto
 STR_AI_CONFIG_RANDOM_AI                                         :Hazarda AI
 STR_AI_CONFIG_NONE                                              :(neniu)
@@ -4539,12 +4582,14 @@ STR_AI_CONFIG_GAMESCRIPT                                        :{SILVER}Ludoskr
 STR_AI_CONFIG_GAMESCRIPT_PARAM                                  :{SILVER}Parametroj
 STR_AI_CONFIG_AI                                                :{SILVER}AIj
 
+STR_AI_CONFIG_CHANGE_AI                                         :{BLACK}Elektu AIon
 STR_AI_CONFIG_CHANGE_GAMESCRIPT                                 :{BLACK}Elektu ludoskripton
 STR_AI_CONFIG_CHANGE_TOOLTIP                                    :{BLACK}Ŝarĝu alian skripton. Stir+Klak por montri ĉiujn haveblajn versiojn
 STR_AI_CONFIG_CONFIGURE                                         :{BLACK}Agordi
 STR_AI_CONFIG_CONFIGURE_TOOLTIP                                 :{BLACK}Agordi parametroj de la skripto
 
 # Available AIs window
+STR_AI_LIST_CAPTION                                             :{WHITE}Haveblaj {STRING}
 STR_AI_LIST_CAPTION_AI                                          :AIoj
 STR_AI_LIST_CAPTION_GAMESCRIPT                                  :Ludoskriptoj
 STR_AI_LIST_TOOLTIP                                             :{BLACK}Klaki por elekti skripto
@@ -5528,6 +5573,10 @@ STR_JUST_DATE_SHORT                                             :{DATE_SHORT}
 STR_JUST_DATE_LONG                                              :{DATE_LONG}
 STR_JUST_DATE_ISO                                               :{DATE_ISO}
 STR_JUST_STRING                                                 :{STRING}
+STR_JUST_STRING1                                                :{STRING}
+STR_JUST_STRING1.n                                              :{STRING.n}
+STR_JUST_STRING2                                                :{STRING}
+STR_JUST_STRING2.n                                              :{STRING.n}
 STR_JUST_STRING_STRING                                          :{STRING}{STRING}
 STR_JUST_RAW_STRING                                             :{STRING}
 STR_JUST_BIG_RAW_STRING                                         :{BIG_FONT}{STRING}

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -4573,6 +4573,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Attendu
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Planifié
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Alterner entre attendu et planifié
 
+STR_TIMETABLE_ARRIVAL                                           :A: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :D: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -4229,6 +4229,7 @@ STR_VEHICLE_LIST_MANAGE_LIST                                    :{BLACK}Zarządz
 STR_VEHICLE_LIST_MANAGE_LIST_TOOLTIP                            :{BLACK}Wyślij instrukcje wszystkim pojazdom na tej liście
 STR_VEHICLE_LIST_REPLACE_VEHICLES                               :Zastąp pojazdy
 STR_VEHICLE_LIST_SEND_FOR_SERVICING                             :Wyślij do serwisu
+STR_VEHICLE_LIST_CREATE_GROUP                                   :Stwórz grupę
 STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR                     :{TINY_FONT}{BLACK}Zysk w tym roku: {CURRENCY_LONG} (ostatni rok: {CURRENCY_LONG})
 STR_VEHICLE_LIST_CARGO                                          :[{CARGO_LIST}]
 STR_VEHICLE_LIST_NAME_AND_CARGO                                 :{STRING} {STRING}
@@ -4957,6 +4958,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Wymagany
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Zaplanowany
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Przełącz między spodziewanymi i zaplanowanymi
 
+STR_TIMETABLE_ARRIVAL                                           :P: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :O: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -4573,6 +4573,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Esperado
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Marcado
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Alternar entre tempo esperado e marcado
 
+STR_TIMETABLE_ARRIVAL                                           :C: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :P: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -4759,6 +4759,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Ожид
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}График
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Переключение между графиком движения и ожидаемым временем прибытия/отправления
 
+STR_TIMETABLE_ARRIVAL                                           :Приб: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :Отпр: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -3849,6 +3849,7 @@ STR_VEHICLE_LIST_MANAGE_LIST                                    :{BLACK}Quản l
 STR_VEHICLE_LIST_MANAGE_LIST_TOOLTIP                            :{BLACK}Gửi chỉ dẫn tới toàn bộ phương tiện trong danh sách
 STR_VEHICLE_LIST_REPLACE_VEHICLES                               :Thay phương tiện
 STR_VEHICLE_LIST_SEND_FOR_SERVICING                             :Gửi về bảo trì
+STR_VEHICLE_LIST_CREATE_GROUP                                   :Tạo nhóm
 STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR                     :{TINY_FONT}{BLACK}Lợi nhuận năm nay: {CURRENCY_LONG} (năm ngoái: {CURRENCY_LONG})
 STR_VEHICLE_LIST_CARGO                                          :[{CARGO_LIST}]
 STR_VEHICLE_LIST_NAME_AND_CARGO                                 :{STRING} {STRING}
@@ -4571,6 +4572,8 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Mong mu�
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Chốt lịch
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Chuyển giữa lịch mong muốn và lịch được chốt
 
+STR_TIMETABLE_ARRIVAL                                           :ĐN: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE                                         :KH: {COLOUR}{DATE_TINY}
 
 
 # Date window (for timetable)

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -21,25 +21,7 @@
  */
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast);
 
-#if defined(HAVE_GETIFADDRS)
-static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GETIFADDRS implementation
-{
-	struct ifaddrs *ifap, *ifa;
-
-	if (getifaddrs(&ifap) != 0) return;
-
-	for (ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
-		if (!(ifa->ifa_flags & IFF_BROADCAST)) continue;
-		if (ifa->ifa_broadaddr == nullptr) continue;
-		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
-
-		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
-	}
-	freeifaddrs(ifap);
-}
-
-#elif defined(_WIN32)
+#ifdef _WIN32
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Win32 implementation
 {
 	SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -77,48 +59,22 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Wi
 	closesocket(sock);
 }
 
-#else /* not HAVE_GETIFADDRS */
-
-#include "../../string_func.h"
-
-static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // !GETIFADDRS implementation
+#else /* not WIN32 */
+static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast)
 {
-	SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);
-	if (sock == INVALID_SOCKET) return;
+	struct ifaddrs *ifap, *ifa;
 
-	char buf[4 * 1024]; // Arbitrary buffer size
-	struct ifconf ifconf;
+	if (getifaddrs(&ifap) != 0) return;
 
-	ifconf.ifc_len = sizeof(buf);
-	ifconf.ifc_buf = buf;
-	if (ioctl(sock, SIOCGIFCONF, &ifconf) == -1) {
-		closesocket(sock);
-		return;
+	for (ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
+		if (!(ifa->ifa_flags & IFF_BROADCAST)) continue;
+		if (ifa->ifa_broadaddr == nullptr) continue;
+		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
+
+		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
 	}
-
-	const char *buf_end = buf + ifconf.ifc_len;
-	for (const char *p = buf; p < buf_end;) {
-		const struct ifreq *req = (const struct ifreq*)p;
-
-		if (req->ifr_addr.sa_family == AF_INET) {
-			struct ifreq r;
-
-			strecpy(r.ifr_name, req->ifr_name, lastof(r.ifr_name));
-			if (ioctl(sock, SIOCGIFFLAGS, &r) != -1 &&
-					(r.ifr_flags & IFF_BROADCAST) &&
-					ioctl(sock, SIOCGIFBRDADDR, &r) != -1) {
-				NetworkAddress addr(&r.ifr_broadaddr, sizeof(sockaddr));
-				if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
-			}
-		}
-
-		p += sizeof(struct ifreq);
-#if defined(AF_LINK) && !defined(SUNOS)
-		p += req->ifr_addr.sa_len - sizeof(struct sockaddr);
-#endif
-	}
-
-	closesocket(sock);
+	freeifaddrs(ifap);
 }
 #endif /* all NetworkFindBroadcastIPsInternals */
 

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -78,15 +78,7 @@ typedef unsigned long in_addr_t;
 #	include <netinet/tcp.h>
 #	include <arpa/inet.h>
 #	include <net/if.h>
-/* According to glibc/NEWS, <ifaddrs.h> appeared in glibc-2.3. */
-#	if !defined(__sgi__) && !defined(SUNOS) \
-	   && !(defined(__GLIBC__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 2)) && !defined(__dietlibc__) && !defined(HPUX)
-/* If for any reason ifaddrs.h does not exist on your system, comment out
- *   the following two lines and an alternative way will be used to fetch
- *   the list of IPs from the system. */
-#		include <ifaddrs.h>
-#		define HAVE_GETIFADDRS
-#	endif
+#	include <ifaddrs.h>
 #	if !defined(INADDR_NONE)
 #		define INADDR_NONE 0xffffffff
 #	endif


### PR DESCRIPTION
## Motivation / Problem

According to the code:
* not supported on __sgi__: does not exist anymore since 2009? Since 2012 not supported by GCC anymore, so doubtful there is any C++17 support.
* not supported on SUNOS (i.e. Solaris): is supported since 11.0 (2011); Sun/Oracle's compiler doesn't support any C++17.
* not supported with glibc < 2.3: so supported since 2004; 2.16 adding C11 support, which libstdc++ for C++17 seems to require
* not supported with HP-UX: cmake does not support HP-UX since 3.10 since HP-UX does not support C++11.
* not supported with dietlibc: does not support the C++ part of the library we need

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
